### PR TITLE
BigTable credentials not working correctly

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,7 +58,7 @@ tasks:
 
   docker:
     cmds:
-      - docker build -f ./resources/docker/Dockerfile . -t {{.DOCKER_IMAGE}}:{{.VER_CUT}}
+      - docker build -f ./Dockerfile . -t {{.DOCKER_IMAGE}}:{{.VER_CUT}}
       - docker tag {{.DOCKER_IMAGE}}:{{.VER_CUT}} {{.DOCKER_IMAGE}}:latest
 
   fmt:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Jeffail/shutdown v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/martian/v3 v3.3.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/nats-io/nats-server/v2 v2.10.24

--- a/go.sum
+++ b/go.sum
@@ -1197,7 +1197,6 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/public/components/gcp_bigtable/output.go
+++ b/public/components/gcp_bigtable/output.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/martian/v3/log"
 	"github.com/hashicorp/go-multierror"
 	"github.com/redpanda-data/benthos/v4/public/bloblang"
 	"github.com/redpanda-data/benthos/v4/public/service"
@@ -120,6 +121,7 @@ func NewGCPBigTableOutput(conf *service.ParsedConfig, mgr *service.Resources) (*
 		rke:             rke,
 		rde:             rde,
 		emulated:        emulated,
+		log:             mgr.Logger(),
 	}, nil
 }
 
@@ -132,8 +134,9 @@ type GCPBigTableOutput struct {
 	rde             *bloblang.Executor
 	emulated        string
 
-	c *bigtable.Client
-	t *bigtable.Table
+	c   *bigtable.Client
+	t   *bigtable.Table
+	log *service.Logger
 }
 
 func (g *GCPBigTableOutput) Connect(ctx context.Context) error {
@@ -157,8 +160,11 @@ func (g *GCPBigTableOutput) Connect(ctx context.Context) error {
 			},
 		}
 
-		if g.credentialsJSON != "" {
+		if len(g.credentialsJSON) > 0 {
+			log.Infof("Using provided credentials")
 			opts.CredentialsJSON = []byte(g.credentialsJSON)
+		} else {
+			log.Infof("Using default credentials")
 		}
 
 		creds, err := credentials.DetectDefault(opts)

--- a/public/components/gcp_bigtable/output.go
+++ b/public/components/gcp_bigtable/output.go
@@ -160,19 +160,20 @@ func (g *GCPBigTableOutput) Connect(ctx context.Context) error {
 			},
 		}
 
+		var copts []option.ClientOption
 		if len(g.credentialsJSON) > 0 {
 			log.Infof("Using provided credentials")
-			opts.CredentialsJSON = []byte(g.credentialsJSON)
+			copts = append(copts, option.WithCredentialsJSON([]byte(g.credentialsJSON)))
 		} else {
 			log.Infof("Using default credentials")
+			creds, err := credentials.DetectDefault(opts)
+			if err != nil {
+				return err
+			}
+			copts = append(copts, option.WithAuthCredentials(creds))
 		}
 
-		creds, err := credentials.DetectDefault(opts)
-		if err != nil {
-			return err
-		}
-
-		client, err := bigtable.NewClient(ctx, g.project, g.instance, option.WithAuthCredentials(creds))
+		client, err := bigtable.NewClient(ctx, g.project, g.instance, copts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The previous implementation did not take into account the use of credentials_json. Instead it relied on ADC to authenticate with the GCP service.