### PR TITLE
fix: website build failed after astro version bump

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -7,6 +7,12 @@ import rehypeMermaid from 'rehype-mermaid'
 // https://astro.build/config
 export default defineConfig({
 	site:'https://wombatwisdom.github.io',
+	image: {
+		// Use the passthrough service which doesn't process images
+		service: {
+			entrypoint: 'astro/assets/services/noop',
+		},
+	},
 	markdown: {
 		rehypePlugins: [
 			[rehypeMermaid, { simple: true }],


### PR DESCRIPTION
**problem**

7ac15a6 - "Bump withastro/action from 3 to 4" by dependabot broke the website build process. 

**fix** 

remove optimisation step for SVGs. Sleuthing by your friendly neighborhood Claude: 


```bash
The upgrade from withastro/action@v3 to withastro/action@v4 is causing the Sharp image processing issue. This is a known issue with
  withastro/action v4 where it has problems with Sharp and SVG files.

  The error happens because:
  1. withastro/action v4 has different handling of image optimization
  2. It's trying to process SVG files with Sharp, which is meant for raster images
  3. The Sharp library isn't properly available in the v4 environment when processing SVGs

  To fix this, you could either:
  1. Revert to withastro/action@v3
  2. Configure Astro to skip image optimization for SVGs (which I attempted earlier)
  3. Wait for a fix in withastro/action
```
  
**test**

```bash
cd website && pnpm build
```