### PR TITLE
fix: pin goreleaser and golangci-lint versions in task:setup

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,8 +30,8 @@ tasks:
   setup:
     desc: Setup development environment
     cmds:
-      - go install github.com/goreleaser/goreleaser@latest
-      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - go install github.com/goreleaser/goreleaser/v2@latest
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
   godir:
     cmd: which go


### PR DESCRIPTION
These were pulling in old versions of tools that are not compatible with go 1.25.x