### PR TITLE
 Fix: ibm-mq pass TLS config to client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/mongodb v0.39.0
-	github.com/wombatwisdom/components v0.1.2
+	github.com/wombatwisdom/components v0.1.3
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.mongodb.org/mongo-driver v1.17.4
 	go.opentelemetry.io/otel v1.38.0

--- a/go.sum
+++ b/go.sum
@@ -2100,8 +2100,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/wI2L/jsondiff v0.4.0 h1:iP56F9tK83eiLttg3YdmEENtZnwlYd3ezEpNNnfZVyM=
 github.com/wI2L/jsondiff v0.4.0/go.mod h1:nR/vyy1efuDeAtMwc3AF6nZf/2LD1ID8GTyyJ+K8YB0=
-github.com/wombatwisdom/components v0.1.2 h1:nPtnRIV4b9S+PHcJZ9+n6r3CJ+ANB+lNfn09i+ZpjiE=
-github.com/wombatwisdom/components v0.1.2/go.mod h1:rAXnphBuC1YOT+f0w9aTCIRJVAvHvhlkBs7dl6FrHmY=
+github.com/wombatwisdom/components v0.1.3 h1:NxleMN7B1lBRS+ShotzSUI4adYSuzorlEP/gQrl3NJE=
+github.com/wombatwisdom/components v0.1.3/go.mod h1:rAXnphBuC1YOT+f0w9aTCIRJVAvHvhlkBs7dl6FrHmY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/public/components/wombatwisdom/ibmmq/input.go
+++ b/public/components/wombatwisdom/ibmmq/input.go
@@ -207,6 +207,7 @@ func newInput(conf *service.ParsedConfig, mgr *service.Resources) (service.Batch
 			UserId:           userId,
 			Password:         password,
 			ApplicationName:  applicationName,
+			TLS:              tlsConfig,
 		},
 		QueueName:     queueName,
 		BatchSize:     batchSize,

--- a/public/components/wombatwisdom/ibmmq/output.go
+++ b/public/components/wombatwisdom/ibmmq/output.go
@@ -305,6 +305,7 @@ func newOutput(conf *service.ParsedConfig, mgr *service.Resources) (service.Batc
 			UserId:           userId,
 			Password:         password,
 			ApplicationName:  applicationName,
+			TLS:              tlsConfig,
 		},
 		QueueExpr: wombatwisdom.NewInterpolatedExpression(queueName),
 		Metadata:  metaConfig,


### PR DESCRIPTION
- Properly set the TLS field to tlsConfig in CommonMQConfig struct.
- Fixes #162.
- Bump components to 0.1.3 (https://github.com/wombatwisdom/components/releases/tag/v0.1.3)